### PR TITLE
removed unnecessary cmake option

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -12,7 +12,6 @@ cmake .. \
       -DMODULE_ACTUATORS=ON \
       -DMODULE_MUSCLES=ON \
       -DBINDER_PYTHON3=ON \
-        -DNUMPY_INCLUDES=$PREFIX/numpy/core/include \
         -DPython3_EXECUTABLE=$PREFIX/bin/python \
       -DBINDER_MATLAB=OFF \
         -DMatlab_ezc3d_INSTALL_DIR=$PREFIX/MATLAB


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
